### PR TITLE
Archive with the previous presentations

### DIFF
--- a/docs/source/scion-research/past-meetings.rst
+++ b/docs/source/scion-research/past-meetings.rst
@@ -1,0 +1,38 @@
+SCION RESEARCH Past Meetings
+============================
+
+We keep an archive of past meetings video recordings,
+please check the following table:
+
+
+.. list-table::
+   :widths: 6 1 2 1 1
+   :header-rows: 1
+
+   * - Research Topic
+     - Date
+     - Presenter
+     - Video
+     - Slides
+   * - Debuglet: Programmable and Verifiable Inter-domain Network Telemetry
+     - 29.10.2024
+     - Jonghoon Kwon
+     - `MP4 Video <https://drive.google.com/file/d/1Q75gVT_F8zM0cqWeFOgqjdM3e1CVfDHB/view?usp=drive_link>`__
+     - `PDF <https://drive.google.com/file/d/1Q12OksrZH6p5LcuxhwWZOMMYIm4JBmAq/view?usp=sharing>`__
+   * - Unlocking Path Awareness for Legacy Applications through SCION-IP Translation
+     - 06.11.2024
+     - Lars Christian Schulz
+     - `MP4 Video <https://polybox.ethz.ch/index.php/s/MYS3xHjhP8bUgmi>`__
+     - 
+   * - UMCC: Uncoupling Multipath Congestion Control through Shared Bottleneck
+       Detection in Path-Aware Networks
+     - 12.11.2024
+     - Marten Gartner
+     - 
+     -
+   * - FABRID
+     - 20.11.2024
+     - Marc Wyss
+     - `MP4 Video <https://polybox.ethz.ch/index.php/s/VigRd58aNoCbO9Y>`__
+     - 
+


### PR DESCRIPTION
A new page under `scion-research` that holds links for the videos and slides of past presentations.
