### PR TITLE
Set the width to 90% of the device

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -17,7 +17,12 @@ extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.autosummary',
     'sphinx.ext.intersphinx',
+    # Based on https://stackoverflow.com/a/73210637/817736 :
+    'sphinx_rtd_size',
 ]
+
+# Based on https://stackoverflow.com/a/73210637/817736 :
+sphinx_rtd_size_width = "90%"
 
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3/', None),


### PR DESCRIPTION
Make the width of the HTML pages 90% of the width of the device, instead of capped.

- [ ] Check that it actually works in readthedocs.com 
